### PR TITLE
Added the `data1` to `data4` members missing from `ALLEGRO_USER_EVENT`.

### DIFF
--- a/source/derelict/allegro5/types.d
+++ b/source/derelict/allegro5/types.d
@@ -338,6 +338,10 @@ struct ALLEGRO_TIMER_EVENT {
 struct ALLEGRO_USER_EVENT {
     mixin _AL_EVENT_HEADER!( ALLEGRO_EVENT_SOURCE );
     void* __internal__descr;
+    intptr_t data1;
+    intptr_t data2;
+    intptr_t data3;
+    intptr_t data4;
 }
 
 union ALLEGRO_EVENT {


### PR DESCRIPTION
The `data{1,2,3,4}` members were missing from `ALLEGRO_USER_EVENT`. Minimally tested under Linux in a small ongoing project of mine ( https://github.com/lmbarros/sbxs_dlang/blob/engine/src/sbxs/engine/backends/allegro5/events.d#L190 ).
